### PR TITLE
Fix: StaticPopup API Change

### DIFF
--- a/MailCommander.lua
+++ b/MailCommander.lua
@@ -3033,17 +3033,17 @@ function addon:BuildAddContact()
 		whileDead = 1,
 		OnHide = function(self)
 			ChatEdit_FocusActiveWindow();
-			self.editBox:SetText("");
+			self:GetEditBox():SetText("");
 		end,
 		OnAccept = function(self, data)
-			_G.MailCommander:AddCustomToon(self.editBox:GetText())
-			self.editBox:SetText("");
+			_G.MailCommander:AddCustomToon(self:GetEditBox():GetText())
+			self:GetEditBox():SetText("");
 		end,
 		timeout = 0,
 		EditBoxOnEnterPressed = function(self, data)
 			local parent = self:GetParent();
-			local editBox = parent.editBox;
-			_G.MailCommander:AddCustomToon(self.editBox:GetText())
+			local editBox = parent:GetEditBox();
+			_G.MailCommander:AddCustomToon(editBox:GetText())
 			editBox:SetText("");
 			parent:Hide();
 		end,
@@ -3079,17 +3079,17 @@ function addon:BuildAddCategory()
 		whileDead = 1,
 		OnHide = function(self)
 			ChatEdit_FocusActiveWindow();
-			self.editBox:SetText("");
+			self:GetEditBox():SetText("");
 		end,
 		OnAccept = function(self, data)
-			_G.MailCommander:AddCustomCategory(self.editBox:GetText())
-			self.editBox:SetText("");
+			_G.MailCommander:AddCustomCategory(self:GetEditBox():GetText())
+			self:GetEditBox():SetText("");
 		end,
 		timeout = 0,
 		EditBoxOnEnterPressed = function(self, data)
 			local parent = self:GetParent();
-			local editBox = parent.editBox;
-			_G.MailCommander:AddCustomCategory(self.editBox:GetText())
+			local editBox = parent:GetEditBox();
+			_G.MailCommander:AddCustomCategory(editBox:GetText())
 			editBox:SetText("");
 			parent:Hide();
 		end,
@@ -3126,17 +3126,17 @@ function addon:BuildAddItemid()
 		whileDead = 1,
 		OnHide = function(self)
 			ChatEdit_FocusActiveWindow();
-			self.editBox:SetText("");
+			self:GetEditBox():SetText("");
 		end,
 		OnAccept = function(self, data)
-			_G.MailCommander:AddCustomItemid(self.editBox:GetText())
-			self.editBox:SetText("");
+			_G.MailCommander:AddCustomItemid(self:GetEditBox():GetText())
+			self:GetEditBox():SetText("");
 		end,
 		timeout = 0,
 		EditBoxOnEnterPressed = function(self, data)
 			local parent = self:GetParent();
-			local editBox = parent.editBox;
-			_G.MailCommander:AddCustomItemid(self.editBox:GetText())
+			local editBox = parent:GetEditBox();
+			_G.MailCommander:AddCustomItemid(editBox:GetText())
 			editBox:SetText("");
 			parent:Hide();
 		end,


### PR DESCRIPTION
The edit box popups (e.g. Add Category) are currently broken.

According to [Warcraft Wiki](https://warcraft.wiki.gg/wiki/Patch_11.2.0/API_changes#Breaking_changes), StaticPopup API has been changed since 11.2.0. `self.editBox` must be replaced with `self:GetEditBox()`.

__Not tested in Classic.__
I have not tested this change on Classic, but it appears the new accessor method is also available there.