### PR TITLE
Fix: use new constants to support reagent bag

### DIFF
--- a/MailCommander.lua
+++ b/MailCommander.lua
@@ -57,7 +57,7 @@ local MONEY = MONEY
 local ITEM_BNETACCOUNTBOUND = ITEM_BNETACCOUNTBOUND
 local toc = select(4, GetBuildInfo())
 local ISCLASSIC = WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE
-local NUM_BAG_SLOTS = NUM_BAG_SLOTS or NUM_TOTAL_BAG_FRAMES
+local NUM_BAG_SLOTS = NUM_TOTAL_EQUIPPED_BAG_SLOTS or NUM_BAG_SLOTS or NUM_TOTAL_BAG_FRAMES
 local function keep(toon, id)
 	if not toon then return 0 end
 	return (legacy and db.keep[toon][id] or db.toons[toon].keep[id]) or 0


### PR DESCRIPTION
Related: [#40 on CurseForge](https://legacy.curseforge.com/wow/addons/mailcommander/issues/40)

[Blizzard source](https://github.com/Gethe/wow-ui-source/blob/7e60b8bff91945886412d36ea4610bb6cfe435e4/Interface/AddOns/Blizzard_FrameXMLBase/Constants.lua#L186)